### PR TITLE
Fix PixelGlow being in the wrong place for one frame

### DIFF
--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -295,6 +295,7 @@ function lib.PixelGlow_Start(r,color,N,frequency,length,th,xOffset,yOffset,borde
         f.info.width = nil
         f.info.length = length
     end
+    pUpdate(f, 0)
     f:SetScript("OnUpdate",pUpdate)
 end
 


### PR DESCRIPTION
This fixes the problem reported in https://github.com/WeakAuras/WeakAuras2/issues/2155

The OnUpdate handler fires on the next frame, so we should call it once.