### PR TITLE
Fix division by zero

### DIFF
--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -320,6 +320,7 @@ lib.stopList["Pixel Glow"] = lib.PixelGlow_Stop
 local function acUpdate(self,elapsed)
     local width,height = self:GetSize()
     if width ~= self.info.width or height ~= self.info.height then
+        if width*height == 0 then return end -- Avoid division by zero
         self.info.width = width
         self.info.height = height
         self.info.perimeter = 2*(width+height)


### PR DESCRIPTION
On test clients, in combat, after reloading UI division by zero error pops up on line 339.
Because while loading frame height and width could be returned as 0