### PR TITLE
Fix division per zero error when alpha is set to zero

### DIFF
--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -6,7 +6,7 @@ https://www.wowace.com/projects/libbuttonglow-1-0
 -- luacheck: globals CreateFromMixins ObjectPoolMixin CreateTexturePool CreateFramePool
 
 local MAJOR_VERSION = "LibCustomGlow-1.0"
-local MINOR_VERSION = 17
+local MINOR_VERSION = 18
 if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
 local lib, oldversion = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then return end
@@ -609,6 +609,14 @@ end
 
 local ButtonGlowTextures = {["spark"] = true,["innerGlow"] = true,["innerGlowOver"] = true,["outerGlow"] = true,["outerGlowOver"] = true,["ants"] = true}
 
+local function noZero(num)
+    if num == 0 then
+        return 0.001
+    else
+        return num
+    end
+end
+
 function lib.ButtonGlow_Start(r,color,frequency,frameLevel)
     if not r then
         return
@@ -638,7 +646,7 @@ function lib.ButtonGlow_Start(r,color,frequency,frameLevel)
             for texture in pairs(ButtonGlowTextures) do
                 f[texture]:SetDesaturated(nil)
                 f[texture]:SetVertexColor(1,1,1)
-                local alpha = math.min(f[texture]:GetAlpha()/(f.color and f.color[4] or 1), 1)
+                local alpha = math.min(f[texture]:GetAlpha()/noZero(f.color and f.color[4] or 1), 1)
                 f[texture]:SetAlpha(alpha)
                 updateAlphaAnim(f, 1)
             end
@@ -647,7 +655,7 @@ function lib.ButtonGlow_Start(r,color,frequency,frameLevel)
             for texture in pairs(ButtonGlowTextures) do
                 f[texture]:SetDesaturated(1)
                 f[texture]:SetVertexColor(color[1],color[2],color[3])
-                local alpha = math.min(f[texture]:GetAlpha()/(f.color and f.color[4] or 1)*color[4], 1)
+                local alpha = math.min(f[texture]:GetAlpha()/noZero(f.color and f.color[4] or 1)*color[4], 1)
                 f[texture]:SetAlpha(alpha)
                 updateAlphaAnim(f,color and color[4] or 1)
             end


### PR DESCRIPTION
Fix an error reported on weakauras discord when alpha is set to zero

```
21x ...akAuras/Libs/LibCustomGlow-1.0-17/LibCustomGlow-1.0.lua:651: bad argument #1 to 'SetAlpha' (Usage: self:SetAlpha(alpha))
[string "=[C]"]: in function SetAlpha'
[string "@WeakAuras/Libs/LibCustomGlow-1.0-17/LibCustomGlow-1.0.lua"]:651: in function glowStart'
[string "@WeakAuras/SubRegionTypes/Glow.lua"]:151: in function <WeakAuras/SubRegionTypes/Glow.lua:143>
[string "@WeakAuras/SubRegionTypes/Glow.lua"]:217: in function SetVisible'
[string "@WeakAuras/SubRegionTypes/Glow.lua"]:276: in function SetGlowColor'
[string "local newActiveConditions = {};"]:182: in function ?'
[string "@WeakAuras/Conditions.lua"]:843: in function RunConditions'
[string "@WeakAuras/WeakAuras.lua"]:4663: in function <WeakAuras/WeakAuras.lua:4628>
[string "@WeakAuras/WeakAuras.lua"]:4772: in function UpdatedTriggerState'
[string "@WeakAuras/WeakAuras.lua"]:4492: in function UpdateFakeStatesFor'
[string "@WeakAuras/WeakAuras.lua"]:4465: in function FakeStatesFor'
[string "@WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua"]:1539: in function SyncVisibility'
[string "@WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua"]:1565: in function PriorityShow'
[string "@WeakAurasOptions/OptionsFrames/OptionsFrame.lua"]:1300: in function PickDisplay'
[string "@WeakAurasOptions/WeakAurasOptions.lua"]:1276: in function `PickDisplay'
[string "@WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua"]:523: in function <...eGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua:472>
```

When alpha is set to 0, it make a division by zero and error trigger with SetAlpha(-nan)