### PR TITLE
Fix double release warning

### DIFF
--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -6,7 +6,7 @@ https://www.wowace.com/projects/libbuttonglow-1-0
 -- luacheck: globals CreateFromMixins ObjectPoolMixin CreateTexturePool CreateFramePool
 
 local MAJOR_VERSION = "LibCustomGlow-1.0"
-local MINOR_VERSION = 20
+local MINOR_VERSION = 21
 if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
 local lib, oldversion = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then return end
@@ -736,7 +736,9 @@ end
 
 function lib.ButtonGlow_Stop(r)
     if r._ButtonGlow then
-        if r._ButtonGlow.animIn:IsPlaying() then
+        if r._ButtonGlow.animOut:IsPlaying() then
+            -- Do nothing the animOut finishing will release
+        elseif r._ButtonGlow.animIn:IsPlaying() then
             r._ButtonGlow.animIn:Stop()
             ButtonGlowPool:Release(r._ButtonGlow)
         elseif r:IsVisible() then


### PR DESCRIPTION
A user on https://github.com/WeakAuras/WeakAuras2/issues/5834 reported an error "Attempted to release inactive object", which apparently happened due to:
1) A call to ButtonGlow_Stop, which due to the parent being visible
   starts the animOut animation
2) Before the animOut animation finishes, a second call to
   ButtonGlow_Stop finds the parent hidden, so it immediately releases
   the glow
3) The glow is hidden, calling bgHide, which due to the animOut running
   released the glow

This prevents the second ButtonGlow_Stop call from releasing the glow if the animation is running.