### PR TITLE
bump TOC for 12.0 (Midnight) and fix the "compare with secret" error

### DIFF
--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -546,6 +546,12 @@ end
 
 local function bgUpdate(self, elapsed)
     AnimateTexCoords(self.ants, 256, 256, 48, 48, 22, elapsed, self.throttle);
+    local cooldown = self:GetParent().cooldown;
+    if(cooldown and cooldown:IsShown() and issecretvalue(cooldown:GetCooldownDuration() == false) and cooldown:GetCooldownDuration() > 3000) then
+        self:SetAlpha(0.5);
+    else
+        self:SetAlpha(1.0);
+    end
 end
 
 local function configureButtonGlow(f,alpha)

--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -546,12 +546,6 @@ end
 
 local function bgUpdate(self, elapsed)
     AnimateTexCoords(self.ants, 256, 256, 48, 48, 22, elapsed, self.throttle);
-    local cooldown = self:GetParent().cooldown;
-    if(cooldown and cooldown:IsShown() and cooldown:GetCooldownDuration() > 3000) then
-        self:SetAlpha(0.5);
-    else
-        self:SetAlpha(1.0);
-    end
 end
 
 local function configureButtonGlow(f,alpha)

--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -6,7 +6,7 @@ https://www.wowace.com/projects/libbuttonglow-1-0
 -- luacheck: globals CreateFromMixins ObjectPoolMixin CreateTexturePool CreateFramePool
 
 local MAJOR_VERSION = "LibCustomGlow-1.0"
-local MINOR_VERSION = 22
+local MINOR_VERSION = 23
 if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
 local lib, oldversion = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then return end

--- a/LibCustomGlow-1.0.toc
+++ b/LibCustomGlow-1.0.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 120001, 120000
 ## Title: Lib: CustomGlow
 ## Notes: Creates custom glow functions
 ## Author: deezo

--- a/LibCustomGlow-1.0.toc
+++ b/LibCustomGlow-1.0.toc
@@ -1,4 +1,4 @@
-## Interface: 110000, 110002
+## Interface: 120000
 ## Title: Lib: CustomGlow
 ## Notes: Creates custom glow functions
 ## Author: deezo


### PR DESCRIPTION
This fixes the bug 
```
1419x ...imeline/Libs/LibCustomGlow-1.0-21/LibCustomGlow-1.0.lua:545: attempt to compare a secret value
[AbilityTimeline/Libs/LibCustomGlow-1.0-21/LibCustomGlow-1.0.lua]:545: in function <...imeline/Libs/LibCustomGlow-1.0/LibCustomGlow-1.0.lua:542>

Locals:
self = Frame {
 spark = Texture {
 }
 outerGlowOver = Texture {
 }
 PixelSnapDisabled = true
 innerGlow = Texture {
 }
 throttle = 0.008333
 color = false
 outerGlow = Texture {
 }
 animOut = AnimationGroup {
 }
 animIn = AnimationGroup {
 }
 innerGlowOver = Texture {
 }
 ants = Texture {
 }
}
elapsed = 0.017000
cooldown = ElvUI_Bar1Button3Cooldown {
 _MSQ_Color = <table> {
 }
 _MSQ_Swipe_Hooked = true
 PixelSnapDisabled = true
 Text = FontString {
 }
 isRegisteredCooldown = true
}
(*temporary) = <no value>
(*temporary) = ElvUI_Bar1Button3Cooldown {
 _MSQ_Color = <table> {
 }
 _MSQ_Swipe_Hooked = true
 PixelSnapDisabled = true
 Text = FontString {
 }
 isRegisteredCooldown = true
}
(*temporary) = <no value>
(*temporary) = 48
(*temporary) = 48
(*temporary) = 22
(*temporary) = 0.017000
(*temporary) = 0.008333
(*temporary) = "attempt to compare a secret value"
```

Tested with ElvUI: enable "action bar glows" and then use an ability which leads to the glow. (e. g. Havoc DH Eye Beam -> Blade Dance + Chaos Strike are glowing)

Please advise if this is correct.