### PR TITLE
Support namespaced AnimateTexCoords in 12.1

### DIFF
--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -11,7 +11,7 @@ if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
 local lib, oldversion = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then return end
 local Masque = LibStub("Masque", true)
-local AnimateTexCoords = TextureUtil.AnimateTexCoords or _G.AnimateTexCoords
+local AnimateTexCoords = (TextureUtil and TextureUtil.AnimateTexCoords) or _G.AnimateTexCoords
 
 local isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
 local textureList = {

--- a/LibCustomGlow-1.0.lua
+++ b/LibCustomGlow-1.0.lua
@@ -6,11 +6,12 @@ https://www.wowace.com/projects/libbuttonglow-1-0
 -- luacheck: globals CreateFromMixins ObjectPoolMixin CreateTexturePool CreateFramePool
 
 local MAJOR_VERSION = "LibCustomGlow-1.0"
-local MINOR_VERSION = 24
+local MINOR_VERSION = 25
 if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
 local lib, oldversion = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then return end
 local Masque = LibStub("Masque", true)
+local AnimateTexCoords = TextureUtil.AnimateTexCoords or _G.AnimateTexCoords
 
 local isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
 local textureList = {


### PR DESCRIPTION
## Summary

WoW 12.1 moves `AnimateTexCoords` into `TextureUtil`. LibCustomGlow still calls the old global from the button glow update handler, which will fail once that global is removed.

Resolve the function once when the library loads, preferring the new namespaced API while keeping the global fallback for older clients. The library minor version is bumped so the fixed copy replaces previously loaded versions.
